### PR TITLE
Fix require sentry in index.js

### DIFF
--- a/modules/sentry/index.js
+++ b/modules/sentry/index.js
@@ -10,7 +10,7 @@ module.exports = {
     },
 
     load() {
-        const Sentry = require("./src/sentry.js");  // eslint-disable-line global-require
+        const Sentry = require("./src/sentry.js").default;  // eslint-disable-line global-require
         return new Sentry();
     },
 


### PR DESCRIPTION
We now require `("sentry").default`