### PR TITLE
Fix the tests that failed when testing localstorage features

### DIFF
--- a/modules/sentry/__mocks__/raven-js.js
+++ b/modules/sentry/__mocks__/raven-js.js
@@ -1,1 +1,7 @@
-module.exports = jest.genMockFromModule("raven-js");
+const Raven = jest.genMockFromModule("raven-js");
+
+Raven.config.mockReturnValue({
+    install: jest.fn(),
+});
+
+module.exports = Raven;

--- a/modules/sentry/src/sentry.js
+++ b/modules/sentry/src/sentry.js
@@ -16,7 +16,7 @@ const self = require("../index.js");
 class Sentry {
 
     constructor() {
-        this.userUUID = this.getUserUUID();
+        this.getUserUUID();
         this.setLogLevels(self.app.config.get("capturedLevels"));
 
         if (!self.app.config.get("@obsidian.debug")) {
@@ -131,27 +131,25 @@ class Sentry {
     }
 
     /**
-     * Get the user UUID.
+     * Get the user UUID from local storage otherwise we generate one
      *
      * @returns {string} The user UUID.
      */
     getUserUUID() {
-        let uuid = this.userUUID;
-
         if (!this.userUUID) {
             try {
                 if (window.localStorage.sentryUUID) {
-                    uuid = window.localStorage.sentryUUID;
+                    this.userUUID = window.localStorage.sentryUUID;
                 } else {
-                    uuid = uuidv4();
-                    window.localStorage.sentryUUID = uuid;
+                    this.userUUID = uuidv4();
+                    window.localStorage.sentryUUID = this.userUUID;
                 }
             } catch (e) {
-                uuid = uuidv4();
+                this.userUUID = uuidv4();
             }
         }
 
-        return uuid;
+        return this.userUUID;
     }
 
 }

--- a/modules/sentry/src/sentry.test.js
+++ b/modules/sentry/src/sentry.test.js
@@ -142,10 +142,9 @@ describe("Sentry.getUserUUID", () => {
         }
 
         const sentryInstance = new Sentry();
-        const { userUUID } = sentryInstance;
 
-        expect(userUUID).not.toBeUndefined();
-        expect(userUUID).toEqual(sentryInstance.getUserUUID());
+        expect(sentryInstance.userUUID).not.toBeUndefined();
+        expect(sentryInstance.userUUID).toEqual(sentryInstance.getUserUUID());
     });
 
     test("If there is a Sentry.userUUID in the local storage, Sentry.getUserUUID put it in userUUID", () => {
@@ -166,9 +165,8 @@ describe("Sentry.getUserUUID", () => {
     test("If local storage is not supported, Sentry.getUserUUID generate one", () => {
         // We need a  way to disable local storage in order to test the localstorage fallback code
         const sentryInstance = new Sentry();
-        const { userUUID } = sentryInstance;
 
-        expect(userUUID).not.toBeUndefined();
-        expect(userUUID).toEqual(sentryInstance.getUserUUID());
+        expect(sentryInstance.userUUID).not.toBeUndefined();
+        expect(sentryInstance.userUUID).toEqual(sentryInstance.getUserUUID());
     });
 });

--- a/modules/sentry/src/sentry.test.js
+++ b/modules/sentry/src/sentry.test.js
@@ -132,18 +132,43 @@ describe("Sentry.forwardLog", () => {
 });
 
 describe("Sentry.getUserUUID", () => {
-    test("When there is no Sentry.userUUID, sentry.getUserUUID return a different UUID each times it's called", () => {
-        const sentryInstance = new Sentry();
-        sentryInstance.userUUID = null;
+    test("When there is no user uuid in the local storage, Sentry.getUserUUID generate one and put it in userUUID", () => {
+        // To be sure there is no userUUID stored
+        try {
+            window.localStorage.sentryUUID = undefined;
+        } catch (e) {
+            console.warn("Local sotrage disabled");
+            return;
+        }
 
-        const userUUID = sentryInstance.getUserUUID();
-        localStorage.clear();
-        expect(userUUID).not.toEqual(sentryInstance.getUserUUID());
-        expect(userUUID).toBeDefined();
+        const sentryInstance = new Sentry();
+        const { userUUID } = sentryInstance;
+
+        expect(userUUID).not.toBeUndefined();
+        expect(userUUID).toEqual(sentryInstance.getUserUUID());
     });
 
-    test("If there is a Sentry.userUUID, Sentry.getUserUUID just return Sentry.userUUID", () => {
+    test("If there is a Sentry.userUUID in the local storage, Sentry.getUserUUID put it in userUUID", () => {
+        const uuid = "6cdc6e4d-fe23-48c0-9a1d-40f0960dc284";
+        try {
+            window.localStorage.sentryUUID = uuid;
+        } catch (e) {
+            console.warn("Local sotrage disabled");
+            return;
+        }
+
         const sentryInstance = new Sentry();
+        expect(sentryInstance.userUUID).not.toBeUndefined();
         expect(sentryInstance.userUUID).toEqual(sentryInstance.getUserUUID());
+        expect(sentryInstance.userUUID).toEqual(uuid);
+    });
+
+    test("If local storage is not supported, Sentry.getUserUUID generate one", () => {
+        // We need a  way to disable local storage in order to test the localstorage fallback code
+        const sentryInstance = new Sentry();
+        const { userUUID } = sentryInstance;
+
+        expect(userUUID).not.toBeUndefined();
+        expect(userUUID).toEqual(sentryInstance.getUserUUID());
     });
 });

--- a/modules/sentry/src/sentry.test.js
+++ b/modules/sentry/src/sentry.test.js
@@ -9,9 +9,14 @@ describe("Sentry.constructor", () => {
     test("Constructor correctly initialize member variables", () => {
         const sentryInstance = new Sentry();
 
-        expect(Raven.config).toHaveBeenCalled();
         expect(sentryInstance.userUUID).toEqual(sentryInstance.getUserUUID());
         expect(sentryInstance.capturedLevels).toEqual(["fatal"]);
+    });
+    test("Constructor correctly initialize raven", () => {
+        const sentryInstance = new Sentry();
+
+        expect(Raven.config).toHaveBeenCalled();
+        expect(sentryInstance.ravenClient.install).toHaveBeenCalled();
     });
 });
 

--- a/modules/sentry/src/sentry.test.js
+++ b/modules/sentry/src/sentry.test.js
@@ -133,13 +133,11 @@ describe("Sentry.forwardLog", () => {
 
 describe("Sentry.getUserUUID", () => {
     test("When there is no user uuid in the local storage, Sentry.getUserUUID generate one and put it in userUUID", () => {
-        // To be sure there is no userUUID stored
-        try {
-            window.localStorage.sentryUUID = undefined;
-        } catch (e) {
-            console.warn("Local sotrage disabled");
-            return;
-        }
+        Object.defineProperty(window, "localStorage", {
+            value: {
+            },
+            writable: true,
+        });
 
         const sentryInstance = new Sentry();
 
@@ -149,12 +147,11 @@ describe("Sentry.getUserUUID", () => {
 
     test("If there is a Sentry.userUUID in the local storage, Sentry.getUserUUID put it in userUUID", () => {
         const uuid = "6cdc6e4d-fe23-48c0-9a1d-40f0960dc284";
-        try {
-            window.localStorage.sentryUUID = uuid;
-        } catch (e) {
-            console.warn("Local sotrage disabled");
-            return;
-        }
+        Object.defineProperty(window, "localStorage", {
+            value: {},
+            writable: true,
+        });
+        window.localStorage.sentryUUID = uuid;
 
         const sentryInstance = new Sentry();
         expect(sentryInstance.userUUID).not.toBeUndefined();
@@ -164,6 +161,10 @@ describe("Sentry.getUserUUID", () => {
 
     test("If local storage is not supported, Sentry.getUserUUID generate one", () => {
         // We need a  way to disable local storage in order to test the localstorage fallback code
+        Object.defineProperty(window, "localStorage", {
+            value: null,
+            writable: true,
+        });
         const sentryInstance = new Sentry();
 
         expect(sentryInstance.userUUID).not.toBeUndefined();


### PR DESCRIPTION
Reworked the getUserUUID function of the sentry module

The function function get or generate a uuidv4 and store it in the
property userUUID, so we don't generate a new uuid each time the
function is called

The getUserUUID function still return userUUID

Add some test to the getUserUUID function in order to test when there is
already a uuid in the local storage, when the local storage is empty and
when the local storage is unavailable.