### PR TITLE
Main loop : fix window focus/blur events capture

### DIFF
--- a/modules/main-loop/src/main-loop.js
+++ b/modules/main-loop/src/main-loop.js
@@ -81,10 +81,10 @@ class MainLoop {
             }
             this._loop();
             this.idle = false;
-        }, true);
+        });
         window.addEventListener("blur", () => {
             this.idle = true;
-        }, true);
+        });
     }
 
     /**


### PR DESCRIPTION
Now, in the main-loop, focus/blur events are called only for the window element, not for all it's sub element..
