### PR TITLE
checking if entity exists inside dataStore before removing it

### DIFF
--- a/modules/data-store/src/data-store.js
+++ b/modules/data-store/src/data-store.js
@@ -57,7 +57,11 @@ class DataStore {
             id = entity.id; // eslint-disable-line prefer-destructuring
             realEntity = entity;
         }
-        const path = this[ENTITIES_BY_UUID][id].path; // eslint-disable-line prefer-destructuring
+        const localEntity = this[ENTITIES_BY_UUID][id];
+        if (!localEntity) {
+            return;
+        }
+        const path = localEntity.path; // eslint-disable-line prefer-destructuring
         delete this[ENTITIES_BY_UUID][id];
         const index = this[ENTITIES_BY_PATH][path].indexOf(realEntity);
         this[ENTITIES_BY_PATH][path].splice(index, 1);

--- a/modules/data-store/src/data-store.test.js
+++ b/modules/data-store/src/data-store.test.js
@@ -149,7 +149,7 @@ describe("DataStore.removeEntity", () => {
         const dataStore = new DataStore();
         const entity = new Entity({ id: "entity-0" });
         dataStore.removeEntity(entity.id);
-        expect(self.app.events.emit).not.toBeCalledWith("entity-removed", entity);
+        expect(self.app.events.emit).not.toBeCalled();
     });
 });
 

--- a/modules/data-store/src/data-store.test.js
+++ b/modules/data-store/src/data-store.test.js
@@ -144,6 +144,13 @@ describe("DataStore.removeEntity", () => {
         expect(self.app.events.emit).lastCalledWith("entity-removed", entity);
     });
 
+    test("don't runs 'entity-removed' event if entity is not found inside dataStore", () => {
+        self.app.events.emit.mockClear();
+        const dataStore = new DataStore();
+        const entity = new Entity({ id: "entity-0" });
+        dataStore.removeEntity(entity.id);
+        expect(self.app.events.emit).not.toBeCalledWith("entity-removed", entity);
+    });
 });
 
 describe("DataStore.getEntity", () => {

--- a/modules/data-store/src/data-store.test.js
+++ b/modules/data-store/src/data-store.test.js
@@ -144,7 +144,7 @@ describe("DataStore.removeEntity", () => {
         expect(self.app.events.emit).lastCalledWith("entity-removed", entity);
     });
 
-    test("don't runs 'entity-removed' event if entity is not found inside dataStore", () => {
+    test("doesn't run 'entity-removed' event if entity is not found inside dataStore", () => {
         self.app.events.emit.mockClear();
         const dataStore = new DataStore();
         const entity = new Entity({ id: "entity-0" });


### PR DESCRIPTION
Before asking data store to remove an entity that doesn't exists inside of it was not a managed case. Now dataStore ignores it if it doesn't exist.